### PR TITLE
implemented react-router and basic navbar

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,10 @@
+import { Route, Routes } from "react-router-dom";
 import { useState } from "react";
 import { Box, CssBaseline } from "@mui/material";
 import TopBar from "./components/TopBar";
 import NavBar from "./components/NavBar";
-import TransactionsList from "./components/TransactionsList";
-import BudgetBar from "./components/BudgetBar";
+import Home from "./pages/Home";
+import NoPage from "./pages/NoPage";
 
 const drawerWidth = 240;
 
@@ -16,6 +17,7 @@ export default function App() {
 
   return (
     <Box sx={{ display: "flex" }}>
+      {/* The TopBar and NavBar are always rendered */}
       <CssBaseline />
       <Box
         component="nav"
@@ -42,8 +44,12 @@ export default function App() {
             overflowY: "auto",
           }}
         >
-          <BudgetBar />
-          <TransactionsList />
+          {/* These are the various routes to different pages */}
+          <Routes>
+            <Route path="/" exact element={<Home />} />
+            <Route path="/home" element={<Home />} />
+            <Route path="/*" element={<NoPage />} />
+          </Routes>
         </Box>
       </Box>
     </Box>

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -1,4 +1,6 @@
-import { Box, Drawer, SwipeableDrawer, Typography } from "@mui/material";
+import { Box, Drawer, SwipeableDrawer, Typography, List, ListItemButton, ListItemIcon, ListItemText } from "@mui/material";
+import { Home, BarChart, Flag } from "@mui/icons-material";
+import { Link } from "react-router-dom";
 
 export default function NavBar(props) {
   const isDrawerOpen = props.isDrawerOpen;
@@ -11,19 +13,44 @@ export default function NavBar(props) {
       <Typography variant="h6" component="div">
         Navigation Bar
       </Typography>
+      <List component="nav">
+        {/* Each list item button is a link to another page */}
+        <ListItemButton component={Link} to="/home">
+          <ListItemIcon>
+            <Home />
+          </ListItemIcon>
+          <ListItemText primary="Home" />
+        </ListItemButton>
+        <ListItemButton component={Link} to="/nopage">
+          <ListItemIcon>
+            <BarChart />
+          </ListItemIcon>
+          <ListItemText primary="Analysis" />
+        </ListItemButton>
+        <ListItemButton component={Link} to="/nopage">
+          <ListItemIcon>
+            <Flag />
+          </ListItemIcon>
+          <ListItemText primary="Goals" />
+        </ListItemButton>
+      </List>
     </Box>
   );
 
   return (
-    <Box component="nav" sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }} aria-label="mailbox folders">
+    <Box
+      component="nav"
+      sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
+      aria-label="mailbox folders"
+    >
       <SwipeableDrawer
         variant="temporary"
         open={isDrawerOpen}
         onOpen={handleDrawerToggle}
         onClose={handleDrawerToggle}
         sx={{
-          display: { xs: 'block', sm: 'none' },
-          '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+          display: { xs: "block", sm: "none" },
+          "& .MuiDrawer-paper": { boxSizing: "border-box", width: drawerWidth },
         }}
       >
         {list}
@@ -32,8 +59,8 @@ export default function NavBar(props) {
       <Drawer
         variant="permanent"
         sx={{
-          display: { xs: 'none', sm: 'block' },
-          '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+          display: { xs: "none", sm: "block" },
+          "& .MuiDrawer-paper": { boxSizing: "border-box", width: drawerWidth },
         }}
         open
       >

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { BrowserRouter } from "react-router-dom";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,0 +1,11 @@
+import TransactionsList from "../components/TransactionsList";
+import BudgetBar from "../components/BudgetBar";
+
+export default function Home() {
+    return (
+      <>
+        <BudgetBar />
+        <TransactionsList />
+      </>
+    );
+}

--- a/client/src/pages/NoPage.js
+++ b/client/src/pages/NoPage.js
@@ -1,0 +1,8 @@
+export default function NoPage() {
+  return (
+    <>
+      <h1>No Page Found</h1>
+      <p>The requested page does not exist.</p>
+    </>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@mui/lab": "^5.0.0-alpha.130"
+        "@mui/lab": "^5.0.0-alpha.130",
+        "react-router-dom": "^6.11.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -588,6 +589,14 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -996,6 +1005,36 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "dependencies": {
+        "@remix-run/router": "1.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "dependencies": {
+        "@remix-run/router": "1.6.2",
+        "react-router": "6.11.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {
@@ -1472,6 +1511,11 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
       "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
     },
+    "@remix-run/router": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA=="
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -1822,6 +1866,23 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-router": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "requires": {
+        "@remix-run/router": "1.6.2"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "requires": {
+        "@remix-run/router": "1.6.2",
+        "react-router": "6.11.2"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@mui/lab": "^5.0.0-alpha.130"
+    "@mui/lab": "^5.0.0-alpha.130",
+    "react-router-dom": "^6.11.2"
   }
 }


### PR DESCRIPTION
currently: we have the pages /home and /notfound.
we will probably have the pages /analysis, /community ... so on quite soon.
in all these cases, the topbar and navbar will be always rendered.

but im thinking:
option 1) the page '/' should be our default log in page/ about apge, that the user sees before logging in.
then, the homepage, analysis page should be '/axelteo/home', '/axelteo/analysis', so they can only be accessed after logging in.
option 2)the page '/' should show the same thing as currently (see above), but it is populated with some dummy data, so the user can try out the application without logging in, but no actual request will be made to the database. Then only when u log in will u be able to see your actual data. in this case, the pages will remain '/home', '/analysis', etc.

I'm leaning towards the option 2 (for demo purposes), so that if people see our webpage, lets say for peer review or marking, they can instantly play around with the functionality of our site without having an account.

Btw: changes made include:
1) index.js file: adding the browser router
2) App.js: Adding the routes.
3) Adding pages folder. This should be were we design our home/analysis/community pages... Then we can assign them a route in App.js
4) NavBar.js: included some dummy links and routes